### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show, :destroy]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_product, only: [:show, :edit, :update, :destroy]
   def index
     @products = Product.all.order('created_at DESC')
@@ -37,8 +37,10 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    @product.destroy
-    redirect_to action: :index
+    if current_user.id == @product.user_id
+      @product.destroy
+    end
+      redirect_to root_path
   end
 
   private

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_product, only: [:show, :edit, :update]
+  before_action :authenticate_user!, except: [:index, :show, :destroy]
+  before_action :set_product, only: [:show, :edit, :update, :destroy]
   def index
     @products = Product.all.order('created_at DESC')
   end
@@ -34,6 +34,11 @@ class ProductsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @product.destroy
+    redirect_to action: :index
   end
 
   private

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -29,7 +29,7 @@
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>
-        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%= link_to "購入画面に進む", product_path(@product.id) ,class:"item-red-btn"%>
       <% end %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'products#index'
-  resources :products, only: [:index, :new, :create, :show, :edit, :update]
+  resources :products, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 
 
 end


### PR DESCRIPTION
#what
商品削除機能の実装
#why
商品詳細ページにて商品削除ができるようにするため

【ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画】
https://gyazo.com/c5ac62c39e817bf58ee7acef86d8b261

ご確認のほどよろしくお願いします。
